### PR TITLE
Calls children with a snapshot instead of two arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/axross/repromised.svg)](https://github.com/axross/repromised/stargazers)
 [![GitHub license](https://img.shields.io/github/license/axross/repromised.svg)](https://github.com/axross/repromised/blob/master/LICENSE)
 
-**Repromised** is a component to resolve a promise and provides its' value with
+**Repromised** is a component to build children by resolving a promise with
 [Render Props](https://reactjs.org/docs/render-props.html) pattern.
 
 - 🚀 Dependency free
@@ -31,14 +31,23 @@ npm i -S repromised
 
 #### Props
 
-| Name            | Type                                             | Required | Description                                                                                                                                                        |
-| --------------- | ------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `promise`       | `() => Promise<T>`                               | ✓        | A function returning a promise to resolve (this will be called when the component is mounted)                                                                      |
-| `initial`       | `T`                                              | ✓        | An initial value                                                                                                                                                   |
-| `then`          | `(value: T) => void`                             |          | A callback function which is called when the promise is resolved                                                                                                   |
-| `catch`         | `(err: Error) => void`                           |          | A callback function which is called when the promise is rejected                                                                                                   |
-| `beforeResolve` | `() => void`                                     |          | A callback function which is called before the promise resolves                                                                                                    |
-| `children`      | `(value: T, isProcessing: boolean) => ReactNode` |          | A render props function which provides the resolved value from the promise and whether the promise is processing. If this is omitted, the component renders `null` |
+| Name       | Type                                                                    | Required | Description                                                                      |
+| ---------- | ----------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `promise`  | `() => Promise<Value>`                                                  | ✓        | A function returning a promise (it will be called when the component is mounted) |
+| `initial`  | `Value` (the same type with the value what the promise should resolves) |          | An initial value                                                                 |
+| `children` | `(snapshot: Snapshot) => ReactNode`                                     |          | A render props function                                                          |
+
+#### Snapshot
+
+`<Repromised>` receives children as a render-props pattern function that gives a snapshot object which has the shape like the following:
+
+| Name           | Type                                                    | Description                                                                                                                        |
+| -------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `status`       | `"PENDING"`, `"FULFILLED"` or `"REJECTED"`              | The promise's status. In TypeScript you can use `Status` enum instead of string enum                                               |
+| `value`        | `Value` (the value what the promise resolves) or `null` | The value what the promise resolves. When `status` is `"PENDING"` or `"REJECTED"` and `props.initial` is not given, this is `null` |
+| `error`        | `Error` or `null`                                       | The error when the promise rejects. This is `null` if `status` is not `"REJECTED"`                                                 |
+| `isLoading`    | `boolean`                                               | A short hand value whether the promise's status is `"PENDING"` or not (same with to `status === "PENDING"`).                       |
+| `requireValue` | `Value` (the value what the promise resolves)           | Same as `value` but it throws an error if `value` is `null`                                                                        |
 
 #### Usage
 
@@ -48,10 +57,10 @@ import Repromised from 'repromised';
 
 const SearchResult = ({ query }) => (
   <Repromised promise={() => fetchByQuery(query)} initial={[]} key={query}>
-    {(results, isProcessing) => isProcessing
+    {snapshot => snapshot.isLoading
       ? <Loading />
       : <ResultList>
-          {results.map(result => <ResultListItem result={result} />)}
+          {snapshot.value.map(result => <ResultListItem result={result} />)}
         </ResultList>
     }
   </Repromised>
@@ -64,4 +73,4 @@ MIT
 
 ## Contribute
 
-You can help improving this project leaving Pull requests and helping with Issues.
+Any feedback is welcome! You can help improving this project leaving Pull requests and helping with Issues.

--- a/src/Repromised.tsx
+++ b/src/Repromised.tsx
@@ -3,9 +3,9 @@ import { Attributes, Component, ReactNode } from "react";
 type Children<Value> = (snapshot: Snapshot<Value>) => ReactNode;
 
 export enum Status {
-  Pending,
-  Fulfilled,
-  Rejected
+  Pending = "PENDING",
+  Fulfilled = "FULFILLED",
+  Rejected = "REJECTED"
 }
 
 interface Props<Value> extends Attributes {

--- a/src/__snapshots__/Repromised.test.tsx.snap
+++ b/src/__snapshots__/Repromised.test.tsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`<Repromised> has props.children() as a render-props resolving a promise 1`] = `
-<span>
-  Symbol(returnValue)
-</span>
-`;
-
-exports[`<Repromised> renders null if props.children is void 1`] = `null`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es5",
     "lib": ["es2015", "dom"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
- [x] Change signature
- [x] Modify tests
- [x] Modify document

Also closes #5.